### PR TITLE
Add environment to the instance name like we use to.

### DIFF
--- a/instance.tf
+++ b/instance.tf
@@ -1,6 +1,6 @@
 resource "aws_instance" "default" {
   tags {
-    Name = "${var.role}-${var.project}"
+    Name = "${var.role}-${var.project}-${var.environment}"
     Environment = "${var.environment}"
     Project = "${var.project}"
     Role = "${var.role}"


### PR DESCRIPTION
Is this a good convention to keep?
